### PR TITLE
Add basic test and pytest CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
       
       - name: Run basic tests
         run: |
-          echo "No tests available yet. Add tests in the future."
+          pytest -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ scikit-learn
 jupyter
 requests
 
+pytest

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,22 @@
+import importlib
+
+# List of core dependencies to test for successful import
+DEPENDENCIES = [
+    'transformers',
+    'langchain',
+    'bs4',
+    'scrapy',
+    'mlflow',
+    'docker',
+    'streamlit',
+    'pandas',
+    'numpy',
+    'sklearn',
+    'requests'
+]
+
+
+def test_imports():
+    """Ensure core dependencies can be imported."""
+    for package in DEPENDENCIES:
+        assert importlib.import_module(package) is not None


### PR DESCRIPTION
## Summary
- set up a simple test suite for importing core dependencies
- include pytest in required packages
- run pytest in GitHub Actions workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_6843198adeb083308654c6e7319b783a